### PR TITLE
Add root Vercel configuration for simplify deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "functions": {
+    "api/*.js": { "runtime": "nodejs20.x" }
+  },
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/simplify/api/$1" },
+    { "source": "/(.*)", "destination": "/simplify/public/$1" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https://api.openai.com https://api.stripe.com" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a root-level `vercel.json` that rewrites `/api` requests into `simplify/api`, serves other paths from `simplify/public`, and sets security headers

## Testing
- `vercel --prod --force` *(fails: requires valid authentication token and outbound network access)*
- `curl -s https://simplify.pulsewebpro.com/api/health` *(fails: 403 Forbidden due to proxy restrictions)*
- `curl -s -H "X-Anon-Id: test123" https://simplify.pulsewebpro.com/api/wallet` *(fails: 403 Forbidden due to proxy restrictions)*
- `curl -s -X POST https://simplify.pulsewebpro.com/api/checkout -H "Content-Type: application/json" -H "X-Anon-Id: test123" -d '{"plan":"one"}'` *(fails: 403 Forbidden due to proxy restrictions)*
- `curl -i -X POST https://simplify.pulsewebpro.com/api/stripe-webhook -H "Content-Type: application/json" -d '{"type":"checkout.session.completed"}'` *(fails: 403 Forbidden due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d50950de7c832b9b5eb8fe7183656a