### PR TITLE
Fix: set Vercel runtime to nodejs

### DIFF
--- a/simplify/api/ai.js
+++ b/simplify/api/ai.js
@@ -3,7 +3,7 @@ import { applyCors, extractBearerToken, readJSONBody, sendJSON } from './_utils/
 import { consumeWalletToken } from './claim.js';
 
 export const config = {
-  runtime: 'nodejs18.x'
+  runtime: 'nodejs'
 };
 
 let openaiClient = null;

--- a/simplify/api/checkout.js
+++ b/simplify/api/checkout.js
@@ -2,7 +2,7 @@ import { applyCors, readJSONBody, sendJSON } from './_utils/http.js';
 import { stripe } from './_utils/stripe.js';
 
 export const config = {
-  runtime: 'nodejs18.x'
+  runtime: 'nodejs'
 };
 
 const PLAN_CONFIG = {

--- a/simplify/api/claim.js
+++ b/simplify/api/claim.js
@@ -4,7 +4,7 @@ import { takeCredits } from './_utils/state.js';
 import { normalizeWallet, normalizeUses, refreshSubscription } from './_utils/wallet.js';
 
 export const config = {
-  runtime: 'nodejs18.x'
+  runtime: 'nodejs'
 };
 
 export async function consumeWalletToken(token, { walletUserId } = {}) {

--- a/simplify/api/health.js
+++ b/simplify/api/health.js
@@ -1,7 +1,7 @@
 import { applyCors, sendJSON } from './_utils/http.js';
 
 export const config = {
-  runtime: 'nodejs18.x'
+  runtime: 'nodejs'
 };
 
 export default async function handler(req, res) {

--- a/simplify/api/stripe-webhook.js
+++ b/simplify/api/stripe-webhook.js
@@ -3,7 +3,7 @@ import { stripe, setSubscriptionState } from './_utils/stripe.js';
 import { addCredits } from './_utils/state.js';
 
 export const config = {
-  runtime: 'nodejs18.x'
+  runtime: 'nodejs'
 };
 
 const MAX_BODY = 16 * 1024;

--- a/simplify/api/wallet-init.js
+++ b/simplify/api/wallet-init.js
@@ -4,7 +4,7 @@ import { takeCredits } from './_utils/state.js';
 import { baseWallet, normalizeWallet, normalizeUses, refreshSubscription } from './_utils/wallet.js';
 
 export const config = {
-  runtime: 'nodejs18.x'
+  runtime: 'nodejs'
 };
 
 export default async function handler(req, res) {


### PR DESCRIPTION
Cambia el runtime de `nodejs18.x` a `nodejs` en todos los endpoints API
para cumplir con los requisitos de Vercel y evitar errores de despliegue.
